### PR TITLE
Export component defaults instead of modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ let Section = require('./components/Section');
 let Cell = require('./components/Cell');
 let CustomCell = require('./components/CustomCell');
 
-module.exports.TableView = TableView;
-module.exports.Section = Section;
-module.exports.Cell = Cell;
-module.exports.CustomCell = CustomCell;
+module.exports.TableView = TableView.default;
+module.exports.Section = Section.default;
+module.exports.Cell = Cell.default;
+module.exports.CustomCell = CustomCell.default;


### PR DESCRIPTION
I was receiving `Invariant Violation`s when trying to import and use these modules. I did a bit of digging, and it seems like the root cause was the mix of es6 and es5 exports. Not sure why [this commit](https://github.com/facebook/react-native/commit/dff8f53664009f49756c79f5f7c4982eaa39a5c3) didn't catch this plugin, but referencing the `default` for each of these components allowed me to use them successfully on RN 0.16.0. I'm no JS wizard, and this could be totally wrong. What do you think?

In the meantime, I will be using code like this to render TableView in my project:
```
let { TableView, Section, Cell } = require("react-native-tableview-simple")

TableView = TableView.default
Section = Section.default
Cell = Cell.default
```
