### PR TITLE
no need height for custom cell

### DIFF
--- a/components/CustomCell.js
+++ b/components/CustomCell.js
@@ -56,7 +56,7 @@ const CustomCell = (props) => {
 const styles = StyleSheet.create({
   cell: {
     backgroundColor: '#fff',
-    height: 44,
+    //height: 44,
     justifyContent: 'center',
     paddingLeft: 15,
     paddingRight: 20,


### PR DESCRIPTION
Custom cell should not set height, let it upto component to decide.

once height is set, it can't be undone if need dynamic height