### PR TITLE
Space letters according to Apple Typography guidelines

### DIFF
--- a/components/Cell.js
+++ b/components/Cell.js
@@ -331,6 +331,7 @@ const styles = StyleSheet.create({
   },
   cell_title: {
     fontSize: 16,
+    letterSpacing: -0.32,
     flex: 1,
   },
   cell_leftDetailTitle: {
@@ -346,11 +347,13 @@ const styles = StyleSheet.create({
   },
   cell_rightDetail: {
     fontSize: 16,
+    letterSpacing: -0.32,
     alignSelf: 'center',
     color: '#8E8E93',
   },
   cell_subtitle: {
     fontSize: 11,
+    letterSpacing: 0.066,
   },
   cell_text__disabled: {
     color: 'gray',
@@ -394,6 +397,7 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '400',
     fontFamily: 'Georgia',
+    letterSpacing: -0.24,
   },
   accessory_detailDisclosure: {
     flexDirection: 'row',

--- a/components/Section.js
+++ b/components/Section.js
@@ -174,6 +174,7 @@ const styles = StyleSheet.create({
   },
   sectionheader__text: {
     fontSize: 13,
+    letterSpacing: -0.078,
   },
   sectionfooter: {
     paddingLeft: 15,
@@ -182,6 +183,7 @@ const styles = StyleSheet.create({
   },
   sectionfooter__text: {
     fontSize: 13,
+    letterSpacing: -0.078,
   },
 });
 


### PR DESCRIPTION
This PR implements letter spacing (tracking) from [Apple’s Typography guidelines](https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/). Might want to look into line height as well. The formula used to convert tracking is `Point size * tracking / 1000`. See [this StackOverflow comment](https://stackoverflow.com/questions/2760784/how-to-calculate-css-letter-spacing-v-s-tracking-in-typography#answer-36612356) if you’re curious where the 1000 value comes from.