### PR TITLE
Fix Type Annotation of TableView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -411,7 +411,7 @@ export interface SeparatorProps {
   tintColor?: string;
 }
 
-export class TableView extends React.Component<null> {}
+export class TableView extends React.Component {}
 export class Section extends React.Component<SectionProps> {}
 export class Cell extends React.Component<CellProps> {}
 export class Separator extends React.Component<SeparatorProps> {}


### PR DESCRIPTION
It causes an error when strictNullChecks=true

```
Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TableView> & Readonly<{ children?: ReactNode; }> &...'.
  Type '{ children: Element; }' is not assignable to type 'null'.
```