### PR TITLE
feat: add prop children in cell component

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ To get an idea what you can modify via `props`, have a look at the [examples bel
 | cellAccessoryView                 |               -               |             `React.Component`             | Replace accessory view component (_e.g.: add Switch or ActivityIndicator_)                                                                                                          |
 | cellContentView                   |               -               |             `React.Component`             | Replace content view component                                                                                                                                                      |
 | cellImageView                     |               -               |             `React.Component`             | Replace image view component                                                                                                                                                        |
+children                            |               -               |             `React.Component`             | Additional content to be displayed below the cell. (_e.g: Add Picker or DateTimePicker_)
 | contentContainerStyle             |             `{}`              |          `View.propTypes.style`           | These styles will be applied to the content container which wraps all of the child views. Overrides `cellStyle` (_e.g.: Override paddingLeft and paddingRight or set fixed height_) |
 | detail                            |               -               |           `string` or `number`            | Detail value                                                                                                                                                                        |
 | detailTextProps                   |             `{}`              |             `Text.propTypes`              | These props will be applied to the (left- / right-) detail `Text`-Component.                                                                                                        |
@@ -234,7 +235,7 @@ See the [example below](#render-with-flatlist).
 
 ## Examples
 
-The following examples can be found in the folder `example`.  
+The following examples can be found in the folder `example`.
 To run the example project, follow these steps:
 
 1.  `git clone https://github.com/Purii/react-native-tableview-simple`

--- a/example/App.js
+++ b/example/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   ActivityIndicator,
   Dimensions,
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import {Cell, Section, TableView} from 'react-native-tableview-simple';
+import {Picker} from '@react-native-community/picker';
 
 // Example component for section:headerComponent
 const CustomSectionHeader = () => (
@@ -20,6 +21,8 @@ const CustomSectionHeader = () => (
 );
 
 const App = () => {
+  const [showPicker, setShowPicker] = useState(false);
+
   return (
     <ScrollView contentContainerStyle={styles.stage}>
       <TableView>
@@ -38,6 +41,24 @@ const App = () => {
             accessory="DisclosureIndicator"
             onPress={() => console.log('Heyho!')}
           />
+          <Cell
+            cellStyle="Basic"
+            title="Favorite programming language"
+            onPress={() => setShowPicker((prevValue) => !prevValue)}>
+            {showPicker && (
+              // onStartShouldSetResponderCapture is to disable the Touchable highlight when scrolling over the picker
+              <View onStartShouldSetResponderCapture={() => true}>
+                <Picker>
+                  <Picker.Item label="Java" />
+                  <Picker.Item label="JavaScript" />
+                  <Picker.Item label="C++" />
+                  <Picker.Item label="Ruby" />
+                  <Picker.Item label="Elixir" />
+                  <Picker.Item label="Python" />
+                </Picker>
+              </View>
+            )}
+          </Cell>
         </Section>
         <Section header="DISABLED">
           <Cell cellStyle="Basic" isDisabled title="Basic" />

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -292,6 +292,8 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
+  - RNCPicker (1.8.1):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -343,6 +345,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/callinvoker (from `../node_modules/react-native/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCPicker (from `../node_modules/@react-native-community/picker`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -409,6 +412,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/Vibration"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCPicker:
+    :path: "../node_modules/@react-native-community/picker"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -448,6 +453,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
+  RNCPicker: 914b557e20b3b8317b084aca9ff4b4edb95f61e4
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@react-native-community/picker": "^1.8.1",
     "react": "16.11.0",
     "react-native": "0.62.2",
     "react-native-tableview-simple": "^4.2.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1293,6 +1293,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
+"@react-native-community/picker@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/picker/-/picker-1.8.1.tgz#94f14f0aad98fa7592967b941be97deec95c3805"
+  integrity sha512-Sj9DzX1CSnmYiuEQ5fQhExoo4XjSKoZkqLPAAybycq6RHtCuWppf+eJXRMCOJki25BlKSSt+qVqg0fIe//ujNQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -30,6 +30,7 @@ export interface CellInterface {
   cellAccessoryView?: React.ReactNode;
   cellContentView?: React.ReactNode;
   cellImageView?: React.ReactNode;
+  children?: React.ReactNode;
   contentContainerStyle?: StyleProp<ViewStyle>;
   detail?: string | number;
   detailTextStyle?: StyleProp<TextStyle>;
@@ -67,6 +68,7 @@ const Cell: React.FC<CellInterface> = ({
   cellContentView,
   cellImageView,
   cellAccessoryView,
+  children,
   contentContainerStyle = {},
   detail,
   detailTextStyle = {},
@@ -110,19 +112,11 @@ const Cell: React.FC<CellInterface> = ({
     };
   } = {
     ...styles,
-    cell: [
-      styles.cell,
-      {
-        backgroundColor: backgroundColor || theme.colors.background,
-      },
-      contentContainerStyle,
-    ],
-    cellSafeAreaContainer: [
-      styles.cellSafeAreaContainer,
-      {
-        backgroundColor: backgroundColor || theme.colors.background,
-      },
-    ],
+    cellBackgroundColor: {
+      backgroundColor: backgroundColor || theme.colors.background,
+    },
+    cell: [styles.cell, contentContainerStyle],
+    cellSafeAreaContainer: styles.cellSafeAreaContainer,
     cellTitle: isDisabled
       ? [styles.cellTitle, styles.cellTextDisabled, titleTextStyleDisabled]
       : [
@@ -379,13 +373,18 @@ const Cell: React.FC<CellInterface> = ({
    * Render content of cell
    * @return {View} Complete View with cell elements
    */
-  const renderCell = (): React.ReactNode => (
-    <View style={localStyles.cell}>
-      {cellImageView || renderImageView()}
-      {cellContentView || renderCellContentView()}
-      {cellAccessoryView || renderAccessoryView()}
-    </View>
-  );
+  const renderCell = (): React.ReactNode => {
+    return (
+      <View style={localStyles.cellBackgroundColor}>
+        <View style={localStyles.cell}>
+          {cellImageView || renderImageView()}
+          {cellContentView || renderCellContentView()}
+          {cellAccessoryView || renderAccessoryView()}
+        </View>
+        {children}
+      </View>
+    );
+  };
 
   /**
    * Render content of cell with SafeAreaView
@@ -393,12 +392,17 @@ const Cell: React.FC<CellInterface> = ({
    * @return {View} Complete View with cell elements
    */
   const renderCellWithSafeAreaView = (): React.ReactNode => (
-    <SafeAreaView style={localStyles.cellSafeAreaContainer}>
+    <SafeAreaView
+      style={[
+        localStyles.cellBackgroundColor,
+        localStyles.cellSafeAreaContainer,
+      ]}>
       <View style={localStyles.cell}>
         {cellImageView || renderImageView()}
         {cellContentView || renderCellContentView()}
         {cellAccessoryView || renderAccessoryView()}
       </View>
+      {children}
     </SafeAreaView>
   );
 

--- a/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`renders basic 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -24,9 +24,6 @@ exports[`renders basic 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -76,10 +73,10 @@ exports[`renders with accessory 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -93,9 +90,6 @@ exports[`renders with accessory 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -178,10 +172,10 @@ exports[`renders with testID 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -195,9 +189,6 @@ exports[`renders with testID 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]

--- a/src/components/__tests__/__snapshots__/Cell-LeftDetail.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-LeftDetail.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`renders with accessory 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -24,9 +24,6 @@ exports[`renders with accessory 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -126,10 +123,10 @@ exports[`renders with accessory and onPressDetailAccessory 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -143,9 +140,6 @@ exports[`renders with accessory and onPressDetailAccessory 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -245,10 +239,10 @@ exports[`renders with left detail 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -262,9 +256,6 @@ exports[`renders with left detail 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]

--- a/src/components/__tests__/__snapshots__/Cell-RightDetail.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-RightDetail.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`renders with accessory 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -24,9 +24,6 @@ exports[`renders with accessory 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -127,10 +124,10 @@ exports[`renders with right detail 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -144,9 +141,6 @@ exports[`renders with right detail 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]

--- a/src/components/__tests__/__snapshots__/Cell-Subtitle.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-Subtitle.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`renders with accessory 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -24,9 +24,6 @@ exports[`renders with accessory 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]
@@ -139,10 +136,10 @@ exports[`renders with subtitle 1`] = `
     style={
       Array [
         Object {
-          "flexGrow": 1,
+          "backgroundColor": "#FFF",
         },
         Object {
-          "backgroundColor": "#FFF",
+          "flexGrow": 1,
         },
       ]
     }
@@ -156,9 +153,6 @@ exports[`renders with subtitle 1`] = `
             "minHeight": 44,
             "paddingLeft": 15,
             "paddingRight": 20,
-          },
-          Object {
-            "backgroundColor": "#FFF",
           },
           Object {},
         ]

--- a/src/components/__tests__/__snapshots__/TableView.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TableView.test.tsx.snap
@@ -73,10 +73,10 @@ exports[`renders basic 1`] = `
             style={
               Array [
                 Object {
-                  "flexGrow": 1,
+                  "backgroundColor": "#FFF",
                 },
                 Object {
-                  "backgroundColor": "#FFF",
+                  "flexGrow": 1,
                 },
               ]
             }
@@ -90,9 +90,6 @@ exports[`renders basic 1`] = `
                     "minHeight": 44,
                     "paddingLeft": 15,
                     "paddingRight": 20,
-                  },
-                  Object {
-                    "backgroundColor": "#FFF",
                   },
                   Object {},
                 ]
@@ -176,10 +173,10 @@ exports[`renders basic 1`] = `
           style={
             Array [
               Object {
-                "flexGrow": 1,
+                "backgroundColor": "#FFF",
               },
               Object {
-                "backgroundColor": "#FFF",
+                "flexGrow": 1,
               },
             ]
           }
@@ -193,9 +190,6 @@ exports[`renders basic 1`] = `
                   "minHeight": 44,
                   "paddingLeft": 15,
                   "paddingRight": 20,
-                },
-                Object {
-                  "backgroundColor": "#FFF",
                 },
                 Object {},
               ]
@@ -370,10 +364,10 @@ exports[`renders with appearance auto 1`] = `
             style={
               Array [
                 Object {
-                  "flexGrow": 1,
+                  "backgroundColor": "#FFF",
                 },
                 Object {
-                  "backgroundColor": "#FFF",
+                  "flexGrow": 1,
                 },
               ]
             }
@@ -387,9 +381,6 @@ exports[`renders with appearance auto 1`] = `
                     "minHeight": 44,
                     "paddingLeft": 15,
                     "paddingRight": 20,
-                  },
-                  Object {
-                    "backgroundColor": "#FFF",
                   },
                   Object {},
                 ]
@@ -473,10 +464,10 @@ exports[`renders with appearance auto 1`] = `
           style={
             Array [
               Object {
-                "flexGrow": 1,
+                "backgroundColor": "#FFF",
               },
               Object {
-                "backgroundColor": "#FFF",
+                "flexGrow": 1,
               },
             ]
           }
@@ -490,9 +481,6 @@ exports[`renders with appearance auto 1`] = `
                   "minHeight": 44,
                   "paddingLeft": 15,
                   "paddingRight": 20,
-                },
-                Object {
-                  "backgroundColor": "#FFF",
                 },
                 Object {},
               ]
@@ -667,10 +655,10 @@ exports[`renders with appearance dark 1`] = `
             style={
               Array [
                 Object {
-                  "flexGrow": 1,
+                  "backgroundColor": "#121312",
                 },
                 Object {
-                  "backgroundColor": "#121312",
+                  "flexGrow": 1,
                 },
               ]
             }
@@ -684,9 +672,6 @@ exports[`renders with appearance dark 1`] = `
                     "minHeight": 44,
                     "paddingLeft": 15,
                     "paddingRight": 20,
-                  },
-                  Object {
-                    "backgroundColor": "#121312",
                   },
                   Object {},
                 ]
@@ -770,10 +755,10 @@ exports[`renders with appearance dark 1`] = `
           style={
             Array [
               Object {
-                "flexGrow": 1,
+                "backgroundColor": "#121312",
               },
               Object {
-                "backgroundColor": "#121312",
+                "flexGrow": 1,
               },
             ]
           }
@@ -787,9 +772,6 @@ exports[`renders with appearance dark 1`] = `
                   "minHeight": 44,
                   "paddingLeft": 15,
                   "paddingRight": 20,
-                },
-                Object {
-                  "backgroundColor": "#121312",
                 },
                 Object {},
               ]
@@ -964,10 +946,10 @@ exports[`renders with appearance light 1`] = `
             style={
               Array [
                 Object {
-                  "flexGrow": 1,
+                  "backgroundColor": "#FFF",
                 },
                 Object {
-                  "backgroundColor": "#FFF",
+                  "flexGrow": 1,
                 },
               ]
             }
@@ -981,9 +963,6 @@ exports[`renders with appearance light 1`] = `
                     "minHeight": 44,
                     "paddingLeft": 15,
                     "paddingRight": 20,
-                  },
-                  Object {
-                    "backgroundColor": "#FFF",
                   },
                   Object {},
                 ]
@@ -1067,10 +1046,10 @@ exports[`renders with appearance light 1`] = `
           style={
             Array [
               Object {
-                "flexGrow": 1,
+                "backgroundColor": "#FFF",
               },
               Object {
-                "backgroundColor": "#FFF",
+                "flexGrow": 1,
               },
             ]
           }
@@ -1084,9 +1063,6 @@ exports[`renders with appearance light 1`] = `
                   "minHeight": 44,
                   "paddingLeft": 15,
                   "paddingRight": 20,
-                },
-                Object {
-                  "backgroundColor": "#FFF",
                 },
                 Object {},
               ]


### PR DESCRIPTION
# Why?
It would be nice to be able to render additional components in the cell. Such as an inline picker, DateTime, and so on.

This lib `Eureka` in Swift has some cool examples of cells using inline components
https://github.com/xmartlabs/Eureka/blob/master/Example/Media/RowGifs/EurekaDateInlineRow.gif
https://github.com/xmartlabs/Eureka/blob/master/Example/Media/RowGifs/EurekaDateTimeInlineRow.gif

![uL5K7PUk](https://user-images.githubusercontent.com/6487206/111245932-326d6580-85e4-11eb-95ab-19b3dba941cb.png)
