### PR TITLE
feat(Cell): add prop isInvalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ To get an idea what you can modify via `props`, have a look at the [examples bel
 | highlightActiveOpacity            |             `0.8`             |                 `number`                  | Opacity of cell when touch is active                                                                                                                                                |
 | highlightUnderlayColor            |            `black`            |                 `string`                  | Color of underlay that will show through when touch is active                                                                                                                       |
 | isDisabled                        |            `false`            |                  `bool`                   | Cell is disabled. `onPress` will not get triggered                                                                                                                                  |
+| isInvalid                         |            `false`            |                  `bool`                   | Cell is invalid.                                                                                                                                                                    |
 | image                             |               -               |         `React.Component (Image)`         | Image component displayed on the left. Will resized automatically                                                                                                                   |
 | leftDetailColor                   |           `#007AFF`           |                 `string`                  | Text color of left detail                                                                                                                                                           |
 | rightDetailColor                  |           `#8E8E93`           |                 `string`                  | Text color of right detail                                                                                                                                                          |
@@ -234,7 +235,7 @@ See the [example below](#render-with-flatlist).
 
 ## Examples
 
-The following examples can be found in the folder `example`.  
+The following examples can be found in the folder `example`.
 To run the example project, follow these steps:
 
 1.  `git clone https://github.com/Purii/react-native-tableview-simple`

--- a/example/App.js
+++ b/example/App.js
@@ -39,6 +39,9 @@ const App = () => {
             onPress={() => console.log('Heyho!')}
           />
         </Section>
+        <Section header="Validations" footer="Example of an invalid cell">
+          <Cell title="Invalid cell" isInvalid />
+        </Section>
         <Section header="DISABLED">
           <Cell cellStyle="Basic" isDisabled title="Basic" />
           <Cell

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -40,6 +40,7 @@ export interface CellInterface {
   highlightUnderlayColor?: ViewStyle['backgroundColor'];
   image?: React.ReactElement;
   isDisabled?: boolean;
+  isInvalid?: boolean;
   onPress?: () => void | false;
   onPressDetailAccessory?: () => void | false;
   onUnHighlightRow?(): void;
@@ -76,6 +77,7 @@ const Cell: React.FC<CellInterface> = ({
   highlightUnderlayColor,
   image,
   isDisabled = false,
+  isInvalid = false,
   onPress,
   onPressDetailAccessory,
   onHighlightRow,
@@ -127,7 +129,11 @@ const Cell: React.FC<CellInterface> = ({
       ? [styles.cellTitle, styles.cellTextDisabled, titleTextStyleDisabled]
       : [
           styles.cellTitle,
-          { color: titleTextColor || theme.colors.body },
+          {
+            color: isInvalid
+              ? theme.colors.error
+              : titleTextColor || theme.colors.body,
+          },
           titleTextStyle,
         ],
     cellLeftDetail: [

--- a/src/components/Theme.ts
+++ b/src/components/Theme.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextStyle, ViewStyle } from 'react-native';
+import { PlatformColor, TextStyle, ViewStyle } from 'react-native';
 
 export interface THEME_APPEARANCE {
   colors: {
@@ -9,6 +9,7 @@ export interface THEME_APPEARANCE {
     body: ViewStyle['backgroundColor'] | TextStyle['color'];
     primary: ViewStyle['backgroundColor'] | TextStyle['color'];
     secondary: ViewStyle['backgroundColor'] | TextStyle['color'];
+    error: ViewStyle['backgroundColor'] | TextStyle['color'];
   };
 }
 
@@ -26,6 +27,7 @@ export const THEMES: {
         body: '#000',
         primary: '#007AFF',
         secondary: '#8E8E93',
+        error: PlatformColor('systemRed'),
       },
     },
     dark: {
@@ -36,6 +38,7 @@ export const THEMES: {
         body: '#FFF',
         primary: '#0f64ee',
         secondary: '#aeaeae',
+        error: PlatformColor('systemRed'),
       },
     },
   },

--- a/src/components/__tests__/Cell-Basic.test.tsx
+++ b/src/components/__tests__/Cell-Basic.test.tsx
@@ -26,3 +26,8 @@ it('renders with accessory', () => {
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+it('renders as invalid', () => {
+  const tree = renderer.create(<Cell title="Basic" isInvalid />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
@@ -1,5 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders as invalid 1`] = `
+<View>
+  <RCTSafeAreaView
+    emulateUnlessSupported={true}
+    style={
+      Array [
+        Object {
+          "flexGrow": 1,
+        },
+        Object {
+          "backgroundColor": "#FFF",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 44,
+            "paddingLeft": 15,
+            "paddingRight": 20,
+          },
+          Object {
+            "backgroundColor": "#FFF",
+          },
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexBasis": 0,
+            "flexDirection": "row",
+            "flexGrow": 1,
+            "justifyContent": "center",
+            "paddingVertical": 10,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={true}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "fontSize": 16,
+                "letterSpacing": -0.32,
+              },
+              Object {
+                "color": Object {
+                  "semantic": Array [
+                    "systemRed",
+                  ],
+                },
+              },
+              Object {},
+            ]
+          }
+        >
+          Basic
+        </Text>
+      </View>
+    </View>
+  </RCTSafeAreaView>
+</View>
+`;
+
 exports[`renders basic 1`] = `
 <View>
   <RCTSafeAreaView


### PR DESCRIPTION
# Why?
It would be nice to have some kind of control to mark the cell as invalid when using it along with formik or a different lib.

The lib [Eureka](https://github.com/xmartlabs/Eureka#validations) in Swift has the support of adding validations to the cells. 
![Screenshot from 2021-03-17 22-40-41](https://user-images.githubusercontent.com/6487206/111560703-d5071f00-8771-11eb-8943-aaa240d1399f.png)

So I added a prop `isInvalid` replicating the same behavior

![Screenshot from 2021-03-17 22-48-52](https://user-images.githubusercontent.com/6487206/111561283-fb798a00-8772-11eb-8934-2f82c2cdef5d.png)
