### PR TITLE
chore(compilerOptions): change jsx from react-native to react

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react-native" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationDir": "./lib/typescript",
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */


### PR DESCRIPTION
## Why?
I was writing some tests using jest and I got stuck with the following error:

```
 ReferenceError: React is not defined

      at TableView (node_modules/react-native-tableview-simple/src/components/TableView.tsx:42:3)
      at renderWithHooks (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:6156:18)
      at mountIndeterminateComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:8690:13)
      at beginWork$1 (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10052:16)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14694:12)
      at workLoopSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14667:22)
      at performSyncWorkOnRoot (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14366:11)
      at node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2063:24
      at unstable_runWithPriority (node_modules/react-test-renderer/node_modules/scheduler/cjs/scheduler.development.js:818:12)
      at runWithPriority (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2013:10)
```

After some time debugging, I realized that the problem is in the commonjs compiled components. Take a look at the generated TableView.js 
```js
"use strict";
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
Object.defineProperty(exports, "__esModule", { value: true });
const react_1 = __importDefault(require("react"));
const react_native_1 = require("react-native");
const Theme_1 = require("./Theme");
const TableView = ({ children, appearance = 'auto', customAppearances, style, }) => {
    let themeMode = Theme_1.THEMES?.appearances?.light;
    const systemColorScheme = react_native_1.useColorScheme();
    if (appearance === 'auto' &&
        (systemColorScheme === 'dark' || systemColorScheme === 'light')) {
        themeMode = Theme_1.THEMES?.appearances?.[systemColorScheme];
    }
    else if (appearance === 'light' || appearance === 'dark') {
        themeMode = Theme_1.THEMES?.appearances?.[appearance];
    }
    else if (customAppearances &&
        appearance &&
        Object.prototype.hasOwnProperty.call(customAppearances, appearance)) {
        themeMode = customAppearances[appearance];
    }
    return (<Theme_1.ThemeContext.Provider value={themeMode}>
      <react_native_1.View style={[styles.tableView, style]}>{children}</react_native_1.View>
    </Theme_1.ThemeContext.Provider>);
};
const styles = react_native_1.StyleSheet.create({
    tableView: {
        flexDirection: 'column',
    },
});
exports.default = TableView;
//# sourceMappingURL=TableView.js.map
```

Even though React is defined as `react_1`, Jest throws an error, and manually renaming it to `React` works. 

So after some time searching about that, the only thing I could find is that most posts out there have the `jsx` option as `react`. 
https://reactnative.dev/docs/typescript#adding-typescript-to-an-existing-project

https://stackoverflow.com/a/63679507

Generated output using `jsx: "react"`

```js
return (react_1.default.createElement(Theme_1.ThemeContext.Provider, { value: themeMode },
        react_1.default.createElement(react_native_1.View, { style: [styles.tableView, style] }, children)));
```