### PR TITLE
feat: improve accessibility

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import {
+  AccessibilityRole,
   Platform,
   SafeAreaView,
   StyleSheet,
@@ -16,6 +17,8 @@ import {
 import { ThemeContext } from './Theme';
 
 export interface CellInterface {
+  accessibilityHint?: string;
+  accessibilityRole?: AccessibilityRole;
   accessory?:
     | false
     | 'DisclosureIndicator'
@@ -59,6 +62,8 @@ export interface CellInterface {
 }
 
 const Cell: React.FC<CellInterface> = ({
+  accessibilityHint,
+  accessibilityRole,
   accessory = false,
   accessoryColor,
   accessoryColorDisclosureIndicator,
@@ -414,13 +419,20 @@ const Cell: React.FC<CellInterface> = ({
         underlayColor={highlightUnderlayColor || theme.colors.body}
         onPressIn={onHighlightRow}
         onPressOut={onUnHighlightRow}
-        testID={testID}>
+        testID={testID}
+        accessibilityHint={accessibilityHint}
+        accessibilityRole="button">
         {withSafeAreaView ? renderCellWithSafeAreaView() : renderCell()}
       </TouchableHighlight>
     );
   }
   return (
-    <View testID={testID}>
+    <View
+      accessible
+      accessibilityHint={accessibilityHint}
+      accessibilityRole={accessibilityRole}
+      accessibilityState={{ disabled: isDisabled }}
+      testID={testID}>
       {withSafeAreaView ? renderCellWithSafeAreaView() : renderCell()}
     </View>
   );

--- a/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-Basic.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders basic 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -67,7 +74,14 @@ exports[`renders basic 1`] = `
 `;
 
 exports[`renders with accessory 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -165,6 +179,12 @@ exports[`renders with accessory 1`] = `
 
 exports[`renders with testID 1`] = `
 <View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
   testID="testID"
 >
   <RCTSafeAreaView

--- a/src/components/__tests__/__snapshots__/Cell-LeftDetail.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-LeftDetail.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders with accessory 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -117,7 +124,14 @@ exports[`renders with accessory 1`] = `
 `;
 
 exports[`renders with accessory and onPressDetailAccessory 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -233,7 +247,14 @@ exports[`renders with accessory and onPressDetailAccessory 1`] = `
 `;
 
 exports[`renders with left detail 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={

--- a/src/components/__tests__/__snapshots__/Cell-RightDetail.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-RightDetail.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders with accessory 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -118,7 +125,14 @@ exports[`renders with accessory 1`] = `
 `;
 
 exports[`renders with right detail 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={

--- a/src/components/__tests__/__snapshots__/Cell-Subtitle.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Cell-Subtitle.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders with accessory 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={
@@ -130,7 +137,14 @@ exports[`renders with accessory 1`] = `
 `;
 
 exports[`renders with subtitle 1`] = `
-<View>
+<View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+>
   <RCTSafeAreaView
     emulateUnlessSupported={true}
     style={

--- a/src/components/__tests__/__snapshots__/TableView.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TableView.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`renders basic 1`] = `
     >
       <View>
         <View
+          accessibilityRole="button"
           accessible={true}
           focusable={true}
           onClick={[Function]}
@@ -158,6 +159,7 @@ exports[`renders basic 1`] = `
         </RCTSafeAreaView>
       </View>
       <View
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         onClick={[Function]}
@@ -349,6 +351,7 @@ exports[`renders with appearance auto 1`] = `
     >
       <View>
         <View
+          accessibilityRole="button"
           accessible={true}
           focusable={true}
           onClick={[Function]}
@@ -449,6 +452,7 @@ exports[`renders with appearance auto 1`] = `
         </RCTSafeAreaView>
       </View>
       <View
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         onClick={[Function]}
@@ -640,6 +644,7 @@ exports[`renders with appearance dark 1`] = `
     >
       <View>
         <View
+          accessibilityRole="button"
           accessible={true}
           focusable={true}
           onClick={[Function]}
@@ -740,6 +745,7 @@ exports[`renders with appearance dark 1`] = `
         </RCTSafeAreaView>
       </View>
       <View
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         onClick={[Function]}
@@ -931,6 +937,7 @@ exports[`renders with appearance light 1`] = `
     >
       <View>
         <View
+          accessibilityRole="button"
           accessible={true}
           focusable={true}
           onClick={[Function]}
@@ -1031,6 +1038,7 @@ exports[`renders with appearance light 1`] = `
         </RCTSafeAreaView>
       </View>
       <View
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         onClick={[Function]}


### PR DESCRIPTION
This PR adds the following props:
accessibilityHint: An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.
accessibilityRole: communicates the purpose of a component to the user of an assistive technology.

Besides that, makes the main View `accessible` by default

Native iOS Cell:
![Photo 01-04-21 14 03 20](https://user-images.githubusercontent.com/6487206/113329628-2f68b980-92f4-11eb-81ab-51ce6319b01f.png)

Cell:
![Photo 01-04-21 14 08 05](https://user-images.githubusercontent.com/6487206/113329640-3263aa00-92f4-11eb-9e74-0b643b55187a.png)
