### PR TITLE
Allow promises for onPress prop

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -41,9 +41,9 @@ export interface CellInterface {
   highlightUnderlayColor?: ViewStyle['backgroundColor'];
   image?: React.ReactElement;
   isDisabled?: boolean;
-  onPress?: () => void | false;
-  onLongPress?: () => void | false;
-  onPressDetailAccessory?: () => void | false;
+  onPress?: () => void | Promise<void> | false;
+  onLongPress?: () => void | Promise<void> | false;
+  onPressDetailAccessory?: () => void | Promise<void> | false;
   onUnHighlightRow?(): void;
   onHighlightRow?(): void;
   leftDetailColor?: TextStyle['color'];


### PR DESCRIPTION
React Native touchables don't have any restrictions against using using Promises with the onPress prop, so we should add promises as a valid type for the `onPress`, `onLongPress`, and `onPressDetailAccessory` props.