### PR TITLE
fix on-integer device scaling causing issues with <Separator> hairline widths

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import {
+  PixelRatio,
   Platform,
   SafeAreaView,
   StyleSheet,
@@ -430,7 +431,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: 15,
     paddingRight: 20,
-    minHeight: 44,
+    minHeight: PixelRatio.roundToNearestPixel(44),
     flexDirection: 'row',
   },
   // SafeAreaView only adds padding


### PR DESCRIPTION
Based on the fix provided by @philo23 [here](https://github.com/Purii/react-native-tableview-simple/issues/782#issue-1722437957) - thanks!

Tested on Pixel 7a (shows bug) & iPhone 14 Pro (no bug) - both on physical devices