### PR TITLE
import SafeAreaView from react-native-safe-area-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "react-native-tableview-simple",
+  "name": "clwy-react-native-tableview-simple",
   "description": "React Native component for TableView made with pure CSS",
-  "homepage": "https://github.com/Purii/react-native-tableview-simple",
-  "version": "4.4.1",
+  "homepage": "https://github.com/clwy-cn/clwy-react-native-tableview-simple",
+  "version": "4.5.0",
   "author": "Patrick Böder <hello@patrickpuritscher.com>",
   "scripts": {
     "clean": "watchman watch-del-all && rm -rf node_modules/ && yarn cache clean && yarn",
@@ -49,7 +49,8 @@
   ],
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.64"
+    "react-native": ">=0.64",
+    "react-native-safe-area-context": "~5.6.0"
   },
   "bugs": {
     "url": "https://github.com/Purii/react-native-tableview-simple/issues"

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import {
   PixelRatio,
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -15,6 +14,7 @@ import {
   ImageProps,
 } from 'react-native';
 import { ThemeContext } from './Theme';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 export interface CellInterface {
   accessory?:
@@ -45,8 +45,11 @@ export interface CellInterface {
   onPress?: () => void | false;
   onLongPress?: () => void | false;
   onPressDetailAccessory?: () => void | false;
+
   onUnHighlightRow?(): void;
+
   onHighlightRow?(): void;
+
   leftDetailColor?: TextStyle['color'];
   rightDetailColor?: TextStyle['color'];
   subtitleColor?: TextStyle['color'];
@@ -61,46 +64,46 @@ export interface CellInterface {
 }
 
 const Cell: React.FC<CellInterface> = ({
-  accessory = false,
-  accessoryColor,
-  accessoryColorDisclosureIndicator,
-  allowFontScaling = true,
-  backgroundColor,
-  cellStyle = 'Basic',
-  cellContentView,
-  cellImageView,
-  cellAccessoryView,
-  children,
-  contentContainerStyle = {},
-  detail,
-  detailTextStyle = {},
-  detailTextProps = {},
-  disableImageResize = false,
-  highlightActiveOpacity = 0.8,
-  highlightUnderlayColor,
-  image,
-  isDisabled = false,
-  onPress,
-  onLongPress,
-  onPressDetailAccessory,
-  onHighlightRow,
-  onUnHighlightRow,
-  leftDetailColor,
-  rightDetailColor,
-  subtitleColor,
-  subtitleTextStyle = {},
-  testID,
-  title,
-  titleTextProps = {},
-  titleTextStyle = {},
-  titleTextStyleDisabled = {},
-  titleTextColor,
-  withSafeAreaView = Platform.OS === 'ios'
-    ? parseInt(`${Platform.Version}`, 10) <= 10
-      ? false
-      : true
-    : true,
-}: CellInterface) => {
+                                         accessory = false,
+                                         accessoryColor,
+                                         accessoryColorDisclosureIndicator,
+                                         allowFontScaling = true,
+                                         backgroundColor,
+                                         cellStyle = 'Basic',
+                                         cellContentView,
+                                         cellImageView,
+                                         cellAccessoryView,
+                                         children,
+                                         contentContainerStyle = {},
+                                         detail,
+                                         detailTextStyle = {},
+                                         detailTextProps = {},
+                                         disableImageResize = false,
+                                         highlightActiveOpacity = 0.8,
+                                         highlightUnderlayColor,
+                                         image,
+                                         isDisabled = false,
+                                         onPress,
+                                         onLongPress,
+                                         onPressDetailAccessory,
+                                         onHighlightRow,
+                                         onUnHighlightRow,
+                                         leftDetailColor,
+                                         rightDetailColor,
+                                         subtitleColor,
+                                         subtitleTextStyle = {},
+                                         testID,
+                                         title,
+                                         titleTextProps = {},
+                                         titleTextStyle = {},
+                                         titleTextStyleDisabled = {},
+                                         titleTextColor,
+                                         withSafeAreaView = Platform.OS === 'ios'
+                                           ? parseInt(`${Platform.Version}`, 10) <= 10
+                                             ? false
+                                             : true
+                                           : true,
+                                       }: CellInterface) => {
   const theme = useContext(ThemeContext);
 
   const isPressable = !!onPress || !!onLongPress;
@@ -119,10 +122,10 @@ const Cell: React.FC<CellInterface> = ({
     cellTitle: isDisabled
       ? [styles.cellTitle, styles.cellTextDisabled, titleTextStyleDisabled]
       : [
-          styles.cellTitle,
-          { color: titleTextColor || theme.colors.body },
-          titleTextStyle,
-        ],
+        styles.cellTitle,
+        { color: titleTextColor || theme.colors.body },
+        titleTextStyle,
+      ],
     cellLeftDetail: [
       styles.cellLeftDetail,
       {
@@ -133,9 +136,9 @@ const Cell: React.FC<CellInterface> = ({
     cellLeftDetailTitle: isDisabled
       ? [styles.cellLeftDetailTitle, styles.cellTextDisabled]
       : [
-          styles.cellLeftDetailTitle,
-          { color: titleTextColor || theme.colors.body },
-        ],
+        styles.cellLeftDetailTitle,
+        { color: titleTextColor || theme.colors.body },
+      ],
     cellRightDetail: [
       styles.cellRightDetail,
       {
@@ -391,18 +394,20 @@ const Cell: React.FC<CellInterface> = ({
    * @return {View} Complete View with cell elements
    */
   const renderCellWithSafeAreaView = (): React.ReactNode => (
-    <SafeAreaView
-      style={[
-        localStyles.cellBackgroundColor,
-        localStyles.cellSafeAreaContainer,
-      ]}>
-      <View style={localStyles.cell}>
-        {cellImageView || renderImageView()}
-        {cellContentView || renderCellContentView()}
-        {cellAccessoryView || renderAccessoryView()}
-      </View>
-      {children}
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView
+        style={[
+          localStyles.cellBackgroundColor,
+          localStyles.cellSafeAreaContainer,
+        ]}>
+        <View style={localStyles.cell}>
+          {cellImageView || renderImageView()}
+          {cellContentView || renderCellContentView()}
+          {cellAccessoryView || renderAccessoryView()}
+        </View>
+        {children}
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 
   if (isPressable && !isDisabled) {

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,13 +1,13 @@
 import React, { useContext, useState } from 'react';
 import {
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   View,
   TextStyle,
   ViewStyle,
 } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import Separator from './Separator';
 import { CellInterface } from './Cell';
@@ -37,31 +37,31 @@ export interface SectionInterface {
 }
 
 const Section: React.FC<SectionInterface> = ({
-  allowFontScaling = true,
-  children,
-  footerComponent,
-  headerComponent,
-  footer,
-  footerTextColor,
-  footerTextStyle = {},
-  header,
-  headerTextColor,
-  headerTextStyle = {},
-  hideSeparator = false,
-  hideSurroundingSeparators = false,
-  roundedCorners = false,
-  sectionPaddingBottom = 15,
-  sectionPaddingTop = 15,
-  sectionTintColor,
-  separatorInsetLeft = 15,
-  separatorInsetRight = 0,
-  separatorTintColor,
-  withSafeAreaView = Platform.OS === 'ios'
-    ? parseInt(`${Platform.Version}`, 10) <= 10
-      ? false
-      : true
-    : true,
-}: SectionInterface) => {
+                                               allowFontScaling = true,
+                                               children,
+                                               footerComponent,
+                                               headerComponent,
+                                               footer,
+                                               footerTextColor,
+                                               footerTextStyle = {},
+                                               header,
+                                               headerTextColor,
+                                               headerTextStyle = {},
+                                               hideSeparator = false,
+                                               hideSurroundingSeparators = false,
+                                               roundedCorners = false,
+                                               sectionPaddingBottom = 15,
+                                               sectionPaddingTop = 15,
+                                               sectionTintColor,
+                                               separatorInsetLeft = 15,
+                                               separatorInsetRight = 0,
+                                               separatorTintColor,
+                                               withSafeAreaView = Platform.OS === 'ios'
+                                                 ? parseInt(`${Platform.Version}`, 10) <= 10
+                                                   ? false
+                                                   : true
+                                                 : true,
+                                             }: SectionInterface) => {
   const theme = useContext(ThemeContext);
   const [highlightedRowIndex, setHighlightedRowIndex] = useState<number>();
 
@@ -172,13 +172,15 @@ const Section: React.FC<SectionInterface> = ({
     if (header && withSafeAreaView) {
       return (
         <View style={styles.sectionheader}>
-          <SafeAreaView>
-            <Text
-              allowFontScaling={allowFontScaling}
-              style={localStyles.sectionheaderText}>
-              {header}
-            </Text>
-          </SafeAreaView>
+          <SafeAreaProvider>
+            <SafeAreaView>
+              <Text
+                allowFontScaling={allowFontScaling}
+                style={localStyles.sectionheaderText}>
+                {header}
+              </Text>
+            </SafeAreaView>
+          </SafeAreaProvider>
         </View>
       );
     }

--- a/src/components/Separator.tsx
+++ b/src/components/Separator.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
 import {
   Platform,
-  SafeAreaView,
   StyleSheet,
   View,
   ViewStyle,
 } from 'react-native';
 import { ThemeContext } from './Theme';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 export interface SeparatorInterface {
   backgroundColor?: ViewStyle['backgroundColor'];
@@ -18,17 +18,17 @@ export interface SeparatorInterface {
 }
 
 const Separator: React.FC<SeparatorInterface> = ({
-  backgroundColor,
-  tintColor,
-  isHidden = false,
-  insetLeft = 15,
-  insetRight = 0,
-  withSafeAreaView = Platform.OS === 'ios'
-    ? parseInt(`${Platform.Version}`, 10) <= 10
-      ? false
-      : true
-    : true,
-}) => {
+                                                   backgroundColor,
+                                                   tintColor,
+                                                   isHidden = false,
+                                                   insetLeft = 15,
+                                                   insetRight = 0,
+                                                   withSafeAreaView = Platform.OS === 'ios'
+                                                     ? parseInt(`${Platform.Version}`, 10) <= 10
+                                                       ? false
+                                                       : true
+                                                     : true,
+                                                 }) => {
   const theme = useContext(ThemeContext);
   const localStyles = {
     separator: [
@@ -49,9 +49,11 @@ const Separator: React.FC<SeparatorInterface> = ({
 
   if (withSafeAreaView) {
     return (
-      <SafeAreaView style={localStyles.separator}>
-        <View style={localStyles.separatorInner} />
-      </SafeAreaView>
+      <SafeAreaProvider>
+        <SafeAreaView style={localStyles.separator}>
+          <View style={localStyles.separatorInner} />
+        </SafeAreaView>
+      </SafeAreaProvider>
     );
   }
   return (


### PR DESCRIPTION
WARN：SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context

import SafeAreaView from react-native-safe-area-context